### PR TITLE
Create .nojekyll in GitHub Action workflow

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -45,6 +45,7 @@ jobs:
         git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
         cp -r docs/_build/html/* gh-pages/
         cd gh-pages
+        touch .nojekyll
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add .


### PR DESCRIPTION
My Sphinx docs did not display correctly until I added this line to create a `.nojekyll` file in the `gh-pages` branch root folder. This is because otherwise, the folders beginning with an underscore are ignored by GitHub Pages.